### PR TITLE
Add load_processors and load_logs URL fragment params

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,13 @@ Because of browser limitations, processors that require OS resources
 (filesystem, sockets) are not included (e.g. `dns`, `translate_sid`,
 `rate_limit`, `add_docker_metdata`).
 
+It will load configurations and sample logs from URLs if you set the appropriate
+query parameters in the URL fragment (aka hash). It reads `load_processors`
+and `load_logs` then loads the content from those URLs. This can be used to share
+examples. The format is:
+
+`http://localhost:8084/#?load_processors=PROCESSORS_URL&load_logs=LOGS_URL`
+
 ## Self-hosting
 
 Download a release binary and run it yourself. By default the binary listens

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "axios": "^0.21.1",
     "levenary": "1.1.1",
     "moment": "^2.29.1",
     "react": "^16.12",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import axios from 'axios';
 import './App.css';
 
 import {
@@ -29,6 +30,25 @@ const defaultProcessors = `- dissect:
 
 const defaultLogs = '[2018-12-14T05:35:38.313Z] I santad: action=EXEC|decision=ALLOW|reason=UNKNOWN|sha256=a8defc1b24c45f6dabeb8298af5f8e1daf39e1504e16f878345f15ac94ae96d7|path=';
 
+function getQueryVariable(input, variable) {
+    var query = input.substring(input.indexOf("?")+1);
+    var vars = query.split('&');
+    for (var i = 0; i < vars.length; i++) {
+        var pair = vars[i].split('=');
+        if (decodeURIComponent(pair[0]) === variable) {
+            return decodeURIComponent(pair[1]);
+        }
+    }
+}
+
+function getLoadProcessors() {
+    return getQueryVariable(window.location.hash, "load_processors");
+}
+
+function getLoadLogs() {
+    return getQueryVariable(window.location.hash, "load_logs");
+}
+
 export default class BeatsPlayground extends Component {
     constructor(props) {
         super(props);
@@ -50,6 +70,59 @@ export default class BeatsPlayground extends Component {
             hasError: false,
         };
     }
+
+    componentDidMount() {
+        this.handleHashChange()
+        window.addEventListener("hashchange", this.handleHashChange, false);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("hashchange", this.handleHashChange, false);
+    }
+
+    handleHashChange = () => {
+        const loadProcessorsUrl = getLoadProcessors();
+        if (loadProcessorsUrl) {
+            const request = {
+                url: loadProcessorsUrl,
+                method: 'get'
+            };
+
+            axios(request)
+                .then(res => {
+                    this.setState({
+                        processors: res.data,
+                    });
+                })
+                .catch(error => {
+                    this.setState({
+                        hasError: true,
+                        output: error.response.data
+                    });
+                });
+        }
+
+        const loadLogsUrl = getLoadLogs();
+        if (loadLogsUrl) {
+            const request = {
+                url: loadLogsUrl,
+                method: 'get'
+            };
+
+            axios(request)
+                .then(res => {
+                    this.setState({
+                        logs: res.data,
+                    });
+                })
+                .catch(error => {
+                    this.setState({
+                        hasError: true,
+                        output: error.response.data
+                    });
+                });
+        }
+    };
 
     onChange = (e) => {
         this.setState({

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2741,6 +2741,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.2.tgz#7cf783331320098bfbef620df3b3c770147bc224"
   integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5397,7 +5404,7 @@ focus-lock@^0.8.1:
   dependencies:
     tslib "^1.9.3"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
   integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==


### PR DESCRIPTION
Adding a fragment will cause it to load the processors and logs from a URL. For example:

https://andrewkroh.github.io/beats-playground/#?load_processors=https://gist.githubusercontent.com/andrewkroh/eafd94488dcc6ecce551f906370b1482/raw/decode_cef.yml&load_logs=https://raw.githubusercontent.com/elastic/beats/edb7c3dc9dc400bf650dbed9595014dc1cd67d21/x-pack/filebeat/processors/decode_cef/testdata/samples.log