### PR TITLE
feat(ui): add YAML format button to processors textarea

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '12'
+          node-version: '22'
 
       - name: check fmt
         shell: bash
@@ -42,6 +42,8 @@ jobs:
 
       - name: build
         run: VERSION=${{ github.sha }} make build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: go test
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,15 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '12'
+          node-version: '22'
 
       - name: install gox
         run: go install github.com/mitchellh/gox@latest
 
       - name: build
         run: VERSION=${{ steps.release_version.outputs.tag }} make build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: cross build
         shell: bash

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,8 @@
     "pako": "^2.1.0",
     "react": "^16.12",
     "react-dom": "^16.12",
-    "react-scripts": "4.0.3"
+    "react-scripts": "4.0.3",
+    "yaml": "^2.8.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -67,6 +67,29 @@
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
 
+.yaml-editor-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.yaml-editor-container .euiTextArea {
+    flex: 1;
+}
+
+.yaml-format-button {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+
+.yaml-format-button:hover {
+    opacity: 1;
+}
+
 .beatsPlaygroundFooter {
     padding: 16px;
     text-align: center;

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -54,11 +54,17 @@
     flex: 1;
     min-height: 120px;
     resize: none;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
 
 .beatsPlaygroundPage .euiFlexGroup--main .euiCodeEditorWrapper {
     flex: 1;
     min-height: 300px;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+}
+
+.beatsPlaygroundPage .euiFlexGroup--main .euiCodeEditorWrapper * {
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
 }
 
 .beatsPlaygroundFooter {

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,10 +1,12 @@
 import React, {Component} from 'react';
 import axios from 'axios';
 import pako from 'pako';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import './App.css';
 
 import {
     EuiButton,
+    EuiButtonIcon,
     EuiCodeEditor,
     EuiFlexGroup,
     EuiFlexItem,
@@ -129,6 +131,7 @@ export default class BeatsPlayground extends Component {
             logs: savedLogs,
             output: '',
             hasError: false,
+            formatError: null,
             toasts: [],
         };
     }
@@ -216,6 +219,18 @@ export default class BeatsPlayground extends Component {
             [e.target.name]: e.target.value,
         });
         localStorage.setItem(e.target.name, e.target.value)
+    };
+
+    formatProcessors = () => {
+        try {
+            const parsed = parseYaml(this.state.processors);
+            const formatted = stringifyYaml(parsed, { indent: 2 });
+            this.setState({ processors: formatted, formatError: null });
+            localStorage.setItem('processors', formatted);
+        } catch (e) {
+            this.setState({ formatError: e.message });
+            setTimeout(() => this.setState({ formatError: null }), 3000);
+        }
     };
 
     onExecute = (e) => {
@@ -327,14 +342,28 @@ export default class BeatsPlayground extends Component {
                                                         Documentation</EuiLink>
                                                 </EuiText>
                                             }>
-                                            <EuiTextArea
-                                                name="processors"
-                                                placeholder="- dissect: ..."
-                                                value={this.state.processors}
-                                                isInvalid={this.state.hasError}
-                                                onChange={this.onChange}
-                                                fullWidth
-                                            />
+                                            <div className="yaml-editor-container">
+                                                <EuiTextArea
+                                                    name="processors"
+                                                    placeholder="- dissect: ..."
+                                                    value={this.state.processors}
+                                                    isInvalid={this.state.hasError}
+                                                    onChange={this.onChange}
+                                                    fullWidth
+                                                />
+                                                <EuiToolTip
+                                                    position="left"
+                                                    content={this.state.formatError || "Format YAML"}
+                                                >
+                                                    <EuiButtonIcon
+                                                        className="yaml-format-button"
+                                                        iconType="brush"
+                                                        aria-label="Format YAML"
+                                                        onClick={this.formatProcessors}
+                                                        color={this.state.formatError ? "danger" : "text"}
+                                                    />
+                                                </EuiToolTip>
+                                            </div>
                                         </EuiFormRow>
 
                                         <EuiFormRow

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -12695,6 +12695,11 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yaml@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
+  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
+
 yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"


### PR DESCRIPTION
Add a subtle floating format button inside the YAML textarea that
formats the processors configuration when clicked. Uses the yaml
npm package for parsing and formatting.

- Button appears in bottom-right corner with 50% opacity
- Hover increases opacity to 100%
- Valid YAML: formats with 2-space indentation, saves to localStorage
- Invalid YAML: shows error in tooltip for 3 seconds, input unchanged